### PR TITLE
Some small tweaks to make the per-variant output more useful

### DIFF
--- a/inc/localPhasingCorrectness.h
+++ b/inc/localPhasingCorrectness.h
@@ -36,6 +36,7 @@ typedef struct _variantCorrectness VariantCorrectness;
 struct _variantCorrectness {
     int64_t refPos;
     double correctness;
+    double maxCorrectness;
 };
 
 // note: takes ownership of the alleles list, but not any other pointers
@@ -49,7 +50,7 @@ stHash *getPhasedVariants(const char *vcfFile);
 
 stList *getSharedContigs(stHash *entry1, stHash *entry2);
 
-VariantCorrectness *variantCorrectness_construct(int64_t refPos, double correctness);
+VariantCorrectness *variantCorrectness_construct(int64_t refPos, double correctness, double maxCorrectness);
 
 void variantCorrectness_destruct(VariantCorrectness* vc);
 

--- a/tools/calcLocalPhasingCorrectness.c
+++ b/tools/calcLocalPhasingCorrectness.c
@@ -328,18 +328,8 @@ int main(int argc, char *argv[]) {
             stList *contigVars = stList_get(arbitraryRow, i);
             char *contigName = stList_get(sharedContigs, i);
             for (int64_t j = 0; j < stList_length(contigVars); ++j) {
-                printf("\t%s", contigName);
-            }
-        }
-        printf("\n");
-        // placeholders for decay and length scales
-        printf("%.17g\t%.17g\t%.17g", NAN, NAN, NAN);
-        // the variant position
-        for (int64_t i = 0; i < stList_length(arbitraryRow); ++i) {
-            stList *contigVars = stList_get(arbitraryRow, i);
-            for (int64_t j = 0; j < stList_length(contigVars); ++j) {
                 VariantCorrectness *vc = stList_get(contigVars, j);
-                printf("\t%"PRId64"", vc->refPos);
+                printf("\t%s_%"PRId64"", contigName, vc->refPos);
             }
         }
         printf("\n");
@@ -355,7 +345,12 @@ int main(int argc, char *argv[]) {
                 stList *contigVars = stList_get(lengthScalePerVarContigs, j);
                 for (int64_t k = 0; k < stList_length(contigVars); ++k) {
                     VariantCorrectness *vc = stList_get(contigVars, k);
-                    printf("\t%.17g", vc->correctness);
+                    if (vc->maxCorrectness != 0.0) {
+                        printf("\t%.17g", vc->correctness / vc->maxCorrectness);
+                    }
+                    else {
+                        printf("\t%g", NAN);
+                    }
                 }
             }
             printf("\n");


### PR DESCRIPTION
Better normalization so that we can do apples-to-apples comparisons between two variants, and a slightly altered table format that's easier to parse.